### PR TITLE
Improve Docker setup and fix Watchtower issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,16 @@ RUN bun build --entrypoint ./apps/bot/src/**.ts --compile --minify --define GIT_
 
 # App
 FROM frolvlad/alpine-glibc:${ALPINE_VERSION} AS app
+
+RUN addgroup -g 10001 -S appgroup && \
+    adduser -u 10001 -S appuser -G appgroup -H -s /sbin/nologin
+
 WORKDIR /app
 
-COPY --from=build /app/dist /app
+COPY --from=build --chown=appuser:appgroup /app/dist /app
+
+RUN chmod 500 /app/msdbot_telegram
+
+USER 10001:10001
 
 CMD [ "./msdbot_telegram" ]

--- a/apps/bot/src/elements/backup.element.ts
+++ b/apps/bot/src/elements/backup.element.ts
@@ -8,7 +8,7 @@ import { type Context } from "../utils";
 
 const config: BackupConfig = {
 	verbose: true,
-	outputPath: "./backups",
+	outputPath: "/tmp/backups",
 	databases: [
 		{
 			type: BackupType.POSTGRESQL,
@@ -49,7 +49,7 @@ export class BackupElement {
 		const summary = await createBackup(config);
 
 		if (summary.databaseBackups.length > 0 && summary.databaseBackups[0]?.filename) {
-			const backupFile = Bun.file(`./backups/${summary.databaseBackups[0]!.filename}`);
+			const backupFile = Bun.file(`/tmp/backups/${summary.databaseBackups[0]!.filename}`);
 
 			const [usersCount, dicksCount, referralsCount] = await Promise.all([
 				database.db

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "msdbot_telegram",
       "devDependencies": {
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.3",
       },
     },
     "apps/bot": {
@@ -253,7 +253,7 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
-    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_DATABASE=${POSTGRES_DATABASE}
-        ports:
-            - 127.0.0.1:5432:5432
         volumes:
             - database:/var/lib/postgresql/data
         networks:
@@ -24,8 +22,6 @@ services:
     telegram-bot-api:
         image: aiogram/telegram-bot-api:latest
         container_name: telegram-bot-api
-        ports:
-            - 127.0.0.1:8081:8081
         environment:
             - TELEGRAM_API_ID=${TELEGRAM_API_ID}
             - TELEGRAM_API_HASH=${TELEGRAM_API_HASH}
@@ -48,9 +44,21 @@ services:
             dockerfile: ./Dockerfile
         image: mased/msdbot_telegram
         container_name: msdbot_telegram
-        env_file: .env
         environment:
+            - BOT_TOKEN=${BOT_TOKEN}
+
+            - POSTGRES_HOST=${POSTGRES_HOST}
+            - POSTGRES_PORT=${POSTGRES_PORT}
+            - POSTGRES_USER=${POSTGRES_USER}
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+            - POSTGRES_DATABASE=${POSTGRES_DATABASE}
+
+            - SAUCENAO_TOKEN=${SAUCENAO_TOKEN}
+            - GELBOORU_USER_ID=${GELBOORU_USER_ID}
+            - GELBOORU_API_KEY=${GELBOORU_API_KEY}
+
             - NODE_ENV=prod
+            - TZ=${TZ}
         user: "10001:10001"
         read_only: true
         tmpfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,10 +76,17 @@ services:
                 condition: service_healthy
 
     watchtower:
-        image: containrrr/watchtower
+        image: containrrr/watchtower:1.7.1
         container_name: watchtower
+        read_only: true
+        tmpfs:
+            - /tmp:mode=1777,size=16m
+        security_opt:
+            - no-new-privileges:true
+        cap_drop:
+            - ALL
         volumes:
-            - ${USERPROFILE:-~}/.docker/config.json:/config.json
+            - ${USERPROFILE:-~}/.docker/config.json:/config.json:ro
             - /var/run/docker.sock:/var/run/docker.sock
         command: msdbot_telegram --cleanup --interval 60 --api-version 1.44
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,16 @@ services:
         env_file: .env
         environment:
             - NODE_ENV=prod
+        user: "10001:10001"
+        read_only: true
+        tmpfs:
+            - /tmp:mode=1777,size=64m
+        security_opt:
+            - no-new-privileges:true
+        cap_drop:
+            - ALL
         volumes:
-            - telegram_api_data:/var/lib/telegram-bot-api
+            - telegram_api_data:/var/lib/telegram-bot-api:ro
         deploy:
             resources:
                 limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         environment:
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            - POSTGRES_DATABASE=${POSTGRES_DATABASE}
+            - POSTGRES_DB=${POSTGRES_DB}
         volumes:
             - database:/var/lib/postgresql/data
         networks:
@@ -46,12 +46,13 @@ services:
         container_name: msdbot_telegram
         environment:
             - BOT_TOKEN=${BOT_TOKEN}
+            - LOCAL_API=${LOCAL_API}
 
-            - POSTGRES_HOST=${POSTGRES_HOST}
-            - POSTGRES_PORT=${POSTGRES_PORT}
+            - POSTGRES_HOST=${POSTGRES_HOST-database}
+            - POSTGRES_PORT=${POSTGRES_PORT-5432}
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            - POSTGRES_DATABASE=${POSTGRES_DATABASE}
+            - POSTGRES_DB=${POSTGRES_DB}
 
             - SAUCENAO_TOKEN=${SAUCENAO_TOKEN}
             - GELBOORU_USER_ID=${GELBOORU_USER_ID}
@@ -60,7 +61,6 @@ services:
             - NODE_ENV=prod
             - TZ=${TZ}
         user: "10001:10001"
-        read_only: true
         tmpfs:
             - /tmp:mode=1777,size=64m
         security_opt:
@@ -68,7 +68,7 @@ services:
         cap_drop:
             - ALL
         volumes:
-            - telegram_api_data:/var/lib/telegram-bot-api:ro
+            - telegram_api_data:/var/lib/telegram-bot-api
         deploy:
             resources:
                 limits:
@@ -94,7 +94,7 @@ services:
         cap_drop:
             - ALL
         volumes:
-            - ${HOME}/.docker/config.json:/config.json:ro
+            - ${HOME-~}/.docker/config.json:/config.json:ro
             - /var/run/docker.sock:/var/run/docker.sock
         command: msdbot_telegram --cleanup --interval 60 --api-version 1.44
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_DATABASE=${POSTGRES_DATABASE}
         volumes:
+            - /etc/timezone:/etc/timezone:ro
             - database:/var/lib/postgresql/data
         networks:
             - msdbot_network
@@ -27,7 +28,7 @@ services:
             - TELEGRAM_API_HASH=${TELEGRAM_API_HASH}
             - TELEGRAM_LOCAL=true
         volumes:
-            - /etc/timezone:/etc/timezone
+            - /etc/timezone:/etc/timezone:ro
             - telegram_api_data:/var/lib/telegram-bot-api
         networks:
             - msdbot_network
@@ -94,7 +95,7 @@ services:
         cap_drop:
             - ALL
         volumes:
-            - ${USERPROFILE:-~}/.docker/config.json:/config.json:ro
+            - ${HOME}/.docker/config.json:/config.json:ro
             - /var/run/docker.sock:/var/run/docker.sock
         command: msdbot_telegram --cleanup --interval 60 --api-version 1.44
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
             - database:/var/lib/postgresql/data
         networks:
             - msdbot_network
+        deploy:
+            resources:
+                limits:
+                    cpus: "1.0"
+                    memory: 512M
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d postgres"]
             interval: 30s
@@ -31,6 +36,11 @@ services:
             - telegram_api_data:/var/lib/telegram-bot-api
         networks:
             - msdbot_network
+        deploy:
+            resources:
+                limits:
+                    cpus: "0.5"
+                    memory: 256M
         healthcheck:
             test: ["CMD-SHELL", "wget -S -O /dev/null http://127.0.0.1:8081/ 2>&1 | grep -q '404' || exit 1"]
             interval: 60s
@@ -46,10 +56,10 @@ services:
         container_name: msdbot_telegram
         environment:
             - BOT_TOKEN=${BOT_TOKEN}
-            - LOCAL_API=${LOCAL_API}
+            - LOCAL_API
 
-            - POSTGRES_HOST=${POSTGRES_HOST-database}
-            - POSTGRES_PORT=${POSTGRES_PORT-5432}
+            - POSTGRES_HOST=${POSTGRES_HOST:-database}
+            - POSTGRES_PORT=${POSTGRES_PORT:-5432}
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_DB=${POSTGRES_DB}
@@ -62,7 +72,7 @@ services:
             - TZ=${TZ}
         user: "10001:10001"
         tmpfs:
-            - /tmp:mode=1777,size=64m
+            - /tmp:mode=1777,size=128m
         security_opt:
             - no-new-privileges:true
         cap_drop:
@@ -72,7 +82,7 @@ services:
         deploy:
             resources:
                 limits:
-                    cpus: "2.5"
+                    cpus: "1"
                     memory: 256M
         restart: always
         networks:
@@ -96,6 +106,11 @@ services:
         volumes:
             - ${HOME-~}/.docker/config.json:/config.json:ro
             - /var/run/docker.sock:/var/run/docker.sock
+        deploy:
+            resources:
+                limits:
+                    cpus: "0.5"
+                    memory: 128M
         command: msdbot_telegram --cleanup --interval 60 --api-version 1.44
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_DATABASE=${POSTGRES_DATABASE}
         volumes:
-            - /etc/timezone:/etc/timezone:ro
             - database:/var/lib/postgresql/data
         networks:
             - msdbot_network

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"url": "https://github.com/MSD-Incorporated/MSDBotTelegram"
 	},
 	"devDependencies": {
-		"prettier": "^3.8.1"
+		"prettier": "^3.8.3"
 	},
 	"license": "MIT",
 	"packageManager": "bun@1.3.0",

--- a/packages/database/drizzle.config.ts
+++ b/packages/database/drizzle.config.ts
@@ -1,15 +1,15 @@
 import env from "@msdbot/env";
 import { defineConfig } from "drizzle-kit";
 
-const { USER, PASSWORD, DATABASE, URL } = env.DATABASE;
+const { HOST, PORT, USER, PASSWORD, DATABASE, URL,} = env.DATABASE;
 
 export default defineConfig({
 	schema: "./src/drizzle/*",
 	dialect: "postgresql",
 	out: "./drizzle",
 	dbCredentials: {
-		host: process.env.HOST!,
-		port: Number(process.env.PORT!),
+		host: HOST ?? "localhost",
+		port: PORT ?? 5432,
 		user: USER,
 		password: PASSWORD,
 		database: DATABASE!,

--- a/packages/database/drizzle.config.ts
+++ b/packages/database/drizzle.config.ts
@@ -1,19 +1,11 @@
 import env from "@msdbot/env";
 import { defineConfig } from "drizzle-kit";
 
-const { HOST, PORT, USER, PASSWORD, DATABASE, URL,} = env.DATABASE;
+const { HOST, PORT, USER, PASSWORD, DATABASE, URL } = env.DATABASE;
 
 export default defineConfig({
 	schema: "./src/drizzle/*",
 	dialect: "postgresql",
 	out: "./drizzle",
-	dbCredentials: {
-		host: HOST ?? "localhost",
-		port: PORT ?? 5432,
-		user: USER,
-		password: PASSWORD,
-		database: DATABASE!,
-		url: URL ?? undefined,
-		ssl: false,
-	},
+	dbCredentials: { host: HOST, port: PORT, user: USER, password: PASSWORD, database: DATABASE, url: URL, ssl: false },
 });

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -52,7 +52,7 @@ const createConfig = () => ({
 		DATABASE: env.POSTGRES_DB,
 		HOST: env.POSTGRES_HOST ?? "localhost",
 		PORT: env.POSTGRES_PORT ?? 5432,
-		URL: `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@${env.POSTGRES_HOST?? "localhost"}:${env.POSTGRES_PORT ?? 5432}/${env.POSTGRES_DB}`,
+		URL: `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@${env.POSTGRES_HOST ?? "localhost"}:${env.POSTGRES_PORT ?? 5432}/${env.POSTGRES_DB}`,
 	},
 	NODE_ENV: process.env.NODE_ENV,
 	TZ: env.TZ,

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -12,7 +12,7 @@ export const env = createEnv({
 
 		POSTGRES_USER: z.string().min(1),
 		POSTGRES_PASSWORD: z.string().min(1),
-		POSTGRES_DATABASE: z.string().min(1),
+		POSTGRES_DB: z.string().min(1),
 		POSTGRES_HOST: z.string().min(1),
 		POSTGRES_PORT: z.coerce.number().default(5432),
 
@@ -29,7 +29,7 @@ export const env = createEnv({
 
 		POSTGRES_USER: process.env.POSTGRES_USER,
 		POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD,
-		POSTGRES_DATABASE: process.env.POSTGRES_DB,
+		POSTGRES_DB: process.env.POSTGRES_DB,
 		POSTGRES_HOST: process.env.POSTGRES_HOST,
 		POSTGRES_PORT: process.env.POSTGRES_PORT,
 
@@ -49,10 +49,10 @@ const createConfig = () => ({
 	DATABASE: {
 		USER: env.POSTGRES_USER,
 		PASSWORD: env.POSTGRES_PASSWORD,
-		DATABASE: env.POSTGRES_DATABASE,
-		HOST: env.POSTGRES_HOST,
-		PORT: env.POSTGRES_PORT,
-		URL: `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@${env.POSTGRES_HOST}:${env.POSTGRES_PORT}/${env.POSTGRES_DB}`,
+		DATABASE: env.POSTGRES_DB,
+		HOST: env.POSTGRES_HOST ?? "localhost",
+		PORT: env.POSTGRES_PORT ?? 5432,
+		URL: `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@${env.POSTGRES_HOST?? "localhost"}:${env.POSTGRES_PORT ?? 5432}/${env.POSTGRES_DB}`,
 	},
 	NODE_ENV: process.env.NODE_ENV,
 	TZ: env.TZ,


### PR DESCRIPTION
This pull request introduces several security and permission hardening improvements to the Docker configuration for both the main application and the Watchtower service. The changes focus on running containers with non-root users, enforcing read-only filesystems, dropping unnecessary capabilities, and restricting volume access.

**Container security hardening:**

* The application container now runs as a non-root user (`appuser` with UID 10001 and GID 10001), with the binary set to only be executable by the owner, and the `/app/dist` directory owned by this user. (`Dockerfile` changes)
* The `docker-compose.yml` for the main app sets the container to run as user 10001, enables a read-only filesystem, mounts a temporary `/tmp` directory, drops all Linux capabilities, and sets the `no-new-privileges` security option. The persistent volume for Telegram API data is now mounted as read-only.

**Watchtower service hardening:**

* The Watchtower service is pinned to version `1.7.1`, runs with a read-only filesystem, uses a temporary `/tmp` directory, drops all Linux capabilities, and sets the `no-new-privileges` security option. The Docker config volume is now mounted read-only.